### PR TITLE
Added top_hit option and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ sample_path:
         /path/to/sample_dir/
 outdir:
         /path/to/output_dir/
+exclude_seqs:
+        FALSE
+top_only:
+        TRUE
+
 ```
+When exclude_seqs is TRUE, query and subject sequences will be extracted from the final blast matrix, and the subject sequences saved as individual fasta files.
+When top_only is TRUE, the final blast matrix only contains tophits for each subject sequences against each query sequences.
 
 The workflow automatically scans the `sample_dir` for `.fasta` files and will attempt to include these in the workflow, using their file name as **sample names** (excluding the  `.fasta` extension. 
 Example:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -9,6 +9,11 @@ sample_path = config["sample_path"]
 outdir = config["outdir"]
 exclude_seqs = config["exclude_seqs"]
 metadata = "%smetadata.tsv" %outdir
+top_only = config["top_only"]
+
+besthit = ""
+if top_only:
+	besthit = "-subject_besthit"
 
 query_path = os.path.dirname(query_file)
 query_name = os.path.basename(query_file).rstrip(".fasta")

--- a/workflow/rules/blast.smk
+++ b/workflow/rules/blast.smk
@@ -12,6 +12,6 @@ rule blast_all:
 	conda:
 		"../envs/blast.yaml"
 	message:
-		"CMD: blastn -query {params.query} -subject {input.fasta} -out {output.blast} -outfmt '6 pident nident length mismatch gapopen bitscore qacc qstart qend qseq sacc sstart send sseq'"
+		"CMD: blastn -query {params.query} -subject {input.fasta} -out {output.blast} -outfmt '6 pident nident length mismatch gapopen bitscore qacc qstart qend qseq sacc sstart send sseq' %s" %besthit
 	shell:
-		"blastn -query {params.query} -subject {input.fasta} -out {output.blast} -outfmt '6 pident nident length mismatch gapopen bitscore qacc qstart qend qseq sacc sstart send sseq'"
+		"blastn -query {params.query} -subject {input.fasta} -out {output.blast} -outfmt '6 pident nident length mismatch gapopen bitscore qacc qstart qend qseq sacc sstart send sseq' %s" %besthit


### PR DESCRIPTION
It is now possible to only extract the top hits in the final blast matrix, in the config/config.yaml file add top_hit: FALSE